### PR TITLE
Add DeepSeekParser unit test

### DIFF
--- a/GlancyTests/GlancyTests.swift
+++ b/GlancyTests/GlancyTests.swift
@@ -11,7 +11,15 @@ import Testing
 struct GlancyTests {
 
     @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        // Encode the static testData into JSON and parse it back using DeepSeekParser
+        let original = DeepSeekTranslationResponse.testData
+        let jsonData = try JSONEncoder().encode(original)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let parsed = try DeepSeekParser.parse(jsonString: jsonString)
+
+        // Verify the word and one of the translations match the original values
+        #expect(parsed.word == original.word)
+        #expect(parsed.translations["en"] == original.translations["en"])
     }
 
 }


### PR DESCRIPTION
## Summary
- add a test for `DeepSeekParser` that parses JSON from `DeepSeekTranslationResponse.testData`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68412f1a59a88332ad1442a3acbda05c