### PR TITLE
Fix docs language links

### DIFF
--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -2,9 +2,9 @@
   <img src="icon.jpg" alt="Glancy App Icon" width="150" style="border-radius: 20px;"/>
 </p>
 
-- [English Version](README.md)
-- [中文版](Docs/README_zh.md)
-- [日本語版](Docs/README_ja.md)
+- [English Version](../README.md)
+- [中文版](README_zh.md)
+- [日本語版](README_ja.md)
 
 # Glancy
 

--- a/Docs/README_zh.md
+++ b/Docs/README_zh.md
@@ -2,9 +2,9 @@
   <img src="icon.jpg" alt="Glancy App Icon" width="150" style="border-radius: 20px;"/>
 </p>
 
-- [English Version](README.md)
-- [中文版](Docs/README_zh.md)
-- [日本語版](Docs/README_ja.md)
+- [English Version](../README.md)
+- [中文版](README_zh.md)
+- [日本語版](README_ja.md)
 
 # Glancy
 


### PR DESCRIPTION
## Summary
- fix relative links in Chinese/Japanese READMEs so they don't 404

## Testing
- `xcodebuild -scheme Glancy -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.0' clean build` *(fails: command not found)*
- `fastlane scan scheme:Glancy output_directory:Reports` *(fails: command not found)*
- `fastlane snapshot devices:"iPhone 15" languages:"en-US,zh-Hans,ja-JP"` *(fails: command not found)*
- `swiftlint --strict` *(fails: command not found)*
- `swiftformat .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d385d088833294fb6be91a3b05ea